### PR TITLE
Added an option to specify the travel mode prior to getting directions

### DIFF
--- a/app/src/main/java/com/example/campusguide/directions/CallbackDirectionsConfirmListener.kt
+++ b/app/src/main/java/com/example/campusguide/directions/CallbackDirectionsConfirmListener.kt
@@ -1,9 +1,9 @@
 package com.example.campusguide.directions
 
-class CallbackDirectionsConfirmListener constructor(private val callback: (String, String) -> Unit)
+class CallbackDirectionsConfirmListener constructor(private val callback: (String, String, String) -> Unit)
     : DirectionsDialogConfirmationListener {
 
-    override fun onConfirm(start: String, end: String) {
-        callback(start, end)
+    override fun onConfirm(start: String, end: String, travelMode: String) {
+        callback(start, end, travelMode)
     }
 }

--- a/app/src/main/java/com/example/campusguide/directions/ChooseDirectionOptions.kt
+++ b/app/src/main/java/com/example/campusguide/directions/ChooseDirectionOptions.kt
@@ -89,9 +89,9 @@ class ChooseDirectionOptions constructor(private val route: Route?) : DialogFrag
                     startingPoint,
                     null,
                     EmptyDirectionsGuard(
-                        CallbackDirectionsConfirmListener { start, end ->
+                        CallbackDirectionsConfirmListener { start, end, travelMode ->
                             //Display the directions time
-                            route?.set(start, end)
+                            route?.set(start, end, travelMode)
                         },
                         DisplayMessageErrorListener(this.requireActivity()))
                 )

--- a/app/src/main/java/com/example/campusguide/directions/ChooseDirectionOptions.kt
+++ b/app/src/main/java/com/example/campusguide/directions/ChooseDirectionOptions.kt
@@ -81,11 +81,11 @@ class ChooseDirectionOptions constructor(private val route: Route?) : DialogFrag
     /**
      * Opens the GetDirectionsDialogFragment
      */
-    private fun openDirectionsDialogFragment(startingPoint: String?, message: String) {
+    private fun openDirectionsDialogFragment(startingPoint: String?, title: String) {
         val getDirectionsDialogFragment =
             GetDirectionsDialogFragment(
                 GetDirectionsDialogFragment.DirectionsDialogOptions(
-                    message,
+                    title,
                     startingPoint,
                     null,
                     EmptyDirectionsGuard(

--- a/app/src/main/java/com/example/campusguide/directions/Directions.kt
+++ b/app/src/main/java/com/example/campusguide/directions/Directions.kt
@@ -15,17 +15,19 @@ class Directions constructor(
      */
     suspend fun getDirections(
         startLocation: String,
-        endLocation: String
+        endLocation: String,
+        travelMode: String
     ): GoogleDirectionsAPIResponse? {
         /**
          * Start and end will be placed in query params, so they must be urlEncoded.
          */
         val startEncoded = URLEncoder.encode(startLocation, "UTF-8")
         val endEncoded = URLEncoder.encode(endLocation, "UTF-8")
+        val travelModeEncoded = URLEncoder.encode(travelMode.toLowerCase(), "UTF-8")
 
         val path = Constants.DIRECTIONS_API_URL
         val url =
-            "$path?origin=$startEncoded&destination=$endEncoded"
+            "$path?origin=$startEncoded&destination=$endEncoded&mode=$travelModeEncoded"
 
         val response = requestDispatcher.sendRequest(url)
         val responseObj = responseParser.parse(response)

--- a/app/src/main/java/com/example/campusguide/directions/DirectionsDialogConfirmationListener.kt
+++ b/app/src/main/java/com/example/campusguide/directions/DirectionsDialogConfirmationListener.kt
@@ -1,5 +1,5 @@
 package com.example.campusguide.directions
 
 interface DirectionsDialogConfirmationListener {
-    fun onConfirm(start: String, end: String)
+    fun onConfirm(start: String, end: String, travelMode: String)
 }

--- a/app/src/main/java/com/example/campusguide/directions/EmptyDirectionsGuard.kt
+++ b/app/src/main/java/com/example/campusguide/directions/EmptyDirectionsGuard.kt
@@ -5,11 +5,11 @@ import com.example.campusguide.utils.ErrorListener
 class EmptyDirectionsGuard constructor(private val wrapped: DirectionsDialogConfirmationListener, private val errorListener: ErrorListener)
     : DirectionsDialogConfirmationListener {
 
-    val errorMessage = "Start and end location must both not be blank"
+    val errorMessage = "Start location, end location and travel mode must all not be blank."
 
-    override fun onConfirm(start: String, end: String) {
-        if(start.isNotEmpty() && end.isNotEmpty()) {
-            wrapped.onConfirm(start, end)
+    override fun onConfirm(start: String, end: String, travelMode: String) {
+        if(start.isNotEmpty() && end.isNotEmpty() && travelMode.isNotEmpty()) {
+            wrapped.onConfirm(start, end, travelMode)
         }
         else {
             errorListener.onError(errorMessage)

--- a/app/src/main/java/com/example/campusguide/directions/GetDirectionsDialogFragment.kt
+++ b/app/src/main/java/com/example/campusguide/directions/GetDirectionsDialogFragment.kt
@@ -2,6 +2,7 @@ package com.example.campusguide.directions
 
 import android.app.AlertDialog
 import android.app.Dialog
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.View
 import android.widget.EditText
@@ -18,13 +19,13 @@ class GetDirectionsDialogFragment constructor(private val options: DirectionsDia
 
     /**
      * Options for creating a Directions dialog.
-     * @param message Displays appropriate instructions to user
+     * @param title Displays appropriate instructions to user
      * @param start Autofills the start location to the specified value
      * @param end Autofills the end location to the specified value
      * @param onConfirm Callback that will be executed when the user confirms the dialog window
      */
     class DirectionsDialogOptions constructor(
-        val message : String?,
+        val title : String?,
         val start: String?, val end: String?,
         val confirmationListener: DirectionsDialogConfirmationListener
     )
@@ -38,12 +39,13 @@ class GetDirectionsDialogFragment constructor(private val options: DirectionsDia
 
             val inflater = requireActivity().layoutInflater
             val view = inflater.inflate(R.layout.directions_dialog_layout, null)
+            var selectedTravelMode = ""
 
             setDefaultLocations(view)
 
             val builder = AlertDialog.Builder(it)
                 .setView(view)
-                .setMessage(this.options.message)
+                .setTitle(this.options.title)
                 .setPositiveButton("Go") { _, _ ->
                     val startEditText =
                         dialog?.findViewById<EditText>(R.id.startLocationTextInput)
@@ -57,6 +59,9 @@ class GetDirectionsDialogFragment constructor(private val options: DirectionsDia
                 .setNegativeButton("Cancel") { dialog, _ ->
                     dialog.cancel()
                 }
+                .setSingleChoiceItems(R.array.travel_modes, -1, DialogInterface.OnClickListener { _, which ->
+                    selectedTravelMode = resources.getStringArray(R.array.travel_modes)[which]
+                })
 
             return builder.create()
         } ?: throw IllegalStateException("Activity cannot be null")

--- a/app/src/main/java/com/example/campusguide/directions/GetDirectionsDialogFragment.kt
+++ b/app/src/main/java/com/example/campusguide/directions/GetDirectionsDialogFragment.kt
@@ -54,7 +54,7 @@ class GetDirectionsDialogFragment constructor(private val options: DirectionsDia
                     val start = startEditText?.text.toString()
                     val end = endEditText?.text.toString()
 
-                    options.confirmationListener.onConfirm(start, end)
+                    options.confirmationListener.onConfirm(start, end, selectedTravelMode)
                 }
                 .setNegativeButton("Cancel") { dialog, _ ->
                     dialog.cancel()

--- a/app/src/main/java/com/example/campusguide/directions/Route.kt
+++ b/app/src/main/java/com/example/campusguide/directions/Route.kt
@@ -48,7 +48,7 @@ class Route constructor(private val map: Map, private val activity: FragmentActi
         return output
     }
 
-    fun set(start: String, end: String) {
+    fun set(start: String, end: String, travelMode: String) {
         polyline?.remove()
         begin?.remove()
         dest?.remove()
@@ -67,7 +67,7 @@ class Route constructor(private val map: Map, private val activity: FragmentActi
 
         //Create a coroutine so we can invoke the suspend function Directions::getDirections
         GlobalScope.launch {
-            val response = directions.getDirections(start, end)
+            val response = directions.getDirections(start, end, travelMode)
             if (response != null) {
                 val startPoint = MarkerOptions().position(
                     LatLng(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,9 @@
     <string name="title_activity_calculator">CalculatorActivity</string>
     <string name="loy_campus">LOY</string>
     <string name="sgw_campus">SGW</string>
+    <string-array name="travel_modes">
+        <item>Driving</item>
+        <item>Walking</item>
+        <item>Transit</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
This is the first iteration of user story #10 

Things that will eventually need to change:

- Specify all three travel modes in the API request so that the user can pick the travel mode and have the associated routes displayed in real time
- Add the Concordia Shuttle as a choice of travel mode
- UI improvements (icons, etc.)