### PR TITLE
Centered the info-window "GO HERE" button for layout purposes

### DIFF
--- a/app/src/main/res/layout/custom_info_marker.xml
+++ b/app/src/main/res/layout/custom_info_marker.xml
@@ -50,6 +50,7 @@
         android:layout_height="wrap_content"
         android:background="@color/colorPrimary"
         android:textColor="@android:color/white"
+        android:layout_gravity="center"
         android:layout_marginBottom="10dp"
         android:text="GO HERE" />
 


### PR DESCRIPTION
Info window pop-up's "GO HERE" button is currently left-aligned. Making it center-aligned for aesthetic purposes until we have a "View indoor floor plans" button to populate the bottom-left side, then the "GO HERE" will be aligned to the bottom-right.