### PR TITLE
Fixed an issue where the wrong LatLng type was being used

### DIFF
--- a/app/src/main/java/com/example/campusguide/search/travelWindow/TravelWindowClickListener.kt
+++ b/app/src/main/java/com/example/campusguide/search/travelWindow/TravelWindowClickListener.kt
@@ -3,10 +3,14 @@ package com.example.campusguide.search.travelWindow
 import com.example.campusguide.directions.DirectionsFlow
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.model.Marker
+import com.google.maps.model.LatLng
 
 class TravelWindowClickListener(private val directions: DirectionsFlow) : GoogleMap.OnInfoWindowClickListener {
     override fun onInfoWindowClick(p0: Marker?) {
         p0!!.remove()
-        directions.startFlow(null, p0!!.position.toString())
+        val coordinates = p0!!.position
+        val coordinatesAsLatLng = LatLng(coordinates.latitude, coordinates.longitude)
+
+        directions.startFlow(null, coordinatesAsLatLng.toString())
     }
 }


### PR DESCRIPTION
That LatLng had a toString that generates a string that doesn't play well with the directions flow and causes it to crash. Now the crash is gone.