### PR TITLE
Fixed an issue where the app would crash when searching for certain indoor rooms

### DIFF
--- a/app/src/main/assets/index/lb.json
+++ b/app/src/main/assets/index/lb.json
@@ -392,6 +392,55 @@
       "code": "3_stair_NW",
       "x": 0.123,
       "y": 0.316,
+      "edges": ["3_num_15"]
+    },
+    {
+      "type": "basic",
+      "code": "3_num_15",
+      "x": 0.253,
+      "y": 0.285,
+      "edges": ["3_hallway_15", "322.00", "314.00"]
+    },
+    {
+      "type": "basic",
+      "code": "3_hallway_15",
+      "x": 0.253,
+      "y": 0.196,
+      "edges": ["3_near_printers", "3_num_15", "311.00", "3_east_hallway_top"]
+    },
+    {
+      "type": "basic",
+      "code": "3_east_hallway_top",
+      "x": 0.029,
+      "y": 0.196,
+      "edges": ["316.00", "3_east_hallway_bot"]
+    },
+    {
+      "type": "basic",
+      "code": "3_east_hallway_bot",
+      "x": 0.029,
+      "y": 0.696,
+      "edges": ["328.00", "3_sw_hallway"]
+    },
+    {
+      "type": "stairs",
+      "code": "3_sw_hallway",
+      "x": 0.204,
+      "y": 0.696,
+      "edges": ["3_sw_intersect", "327.00", "3_mens_east", "3_allgender_east"]
+    },
+    {
+      "type": "bathroom",
+      "code": "3_mens_east",
+      "x": 0.258,
+      "y": 0.579,
+      "edges": []
+    },
+    {
+      "type": "bathroom",
+      "code": "3_allgender_east",
+      "x": 0.258,
+      "y": 0.623,
       "edges": []
     },
     {

--- a/app/src/main/assets/index/lb.json
+++ b/app/src/main/assets/index/lb.json
@@ -252,7 +252,7 @@
       "code": "2_entryway",
       "x": 0.355,
       "y": 0.442,
-      "edges": ["2_near_printers", "2_entry_stairs"]
+      "edges": ["2_near_printers", "2_entry_stairs", "201.01"]
     },
     {
       "type": "elevators",

--- a/app/src/main/java/com/example/campusguide/directions/PathPolyline.kt
+++ b/app/src/main/java/com/example/campusguide/directions/PathPolyline.kt
@@ -72,9 +72,9 @@ class PathPolyline constructor(startName: String, endName: String, val segment: 
 
     fun getPathBounds() : LatLngBounds {
         var north: Double = path[0].latitude
-        var south: Double = path[1].latitude
+        var south: Double = path[0].latitude
         var east: Double = path[0].longitude
-        var west: Double = path[1].longitude
+        var west: Double = path[0].longitude
 
         path.forEach {point ->
             north = Math.max(north, point.latitude)

--- a/app/src/main/java/com/example/campusguide/directions/indoor/FindRoomPathfinding.kt
+++ b/app/src/main/java/com/example/campusguide/directions/indoor/FindRoomPathfinding.kt
@@ -26,6 +26,9 @@ class FindRoomPathfinding(graph: Graph): IndoorPathfinding(graph) {
     }
 
     override fun getResults(): List<String> {
+        if(!complete) {
+            throw PathNotFoundException("Could not find a path to room $target")
+        }
         return listOf(target)
     }
 }

--- a/app/src/main/java/com/example/campusguide/directions/indoor/IndoorPathfinding.kt
+++ b/app/src/main/java/com/example/campusguide/directions/indoor/IndoorPathfinding.kt
@@ -109,3 +109,5 @@ abstract class IndoorPathfinding constructor(private val graph: Graph) {
 }
 
 class NonexistentLocationException(message: String) : RuntimeException(message)
+
+class PathNotFoundException(message: String) : RuntimeException(message)


### PR DESCRIPTION
- Fixed an issue where the application crashed when the length of the directions path was 1 - this issue was caused by the PathPolyline using the 1st and 2nd points in the bath when calculating bounds. Now it only uses the 1st point.

- Added several missing nodes and edges to the LB 2nd and 3rd floor floor plans. This was causing those paths of length 1 to be generated.

- An informative exception is now thrown when no indoor path is found. This should let us know earlier when issues like this happen again.

Future improvements that I don't have time to do right now: Display an error message when no indoor path is found (instead of crashing with an informative exception)

