### PR TITLE
Marker no longer lingers after closing a building info-window popup

### DIFF
--- a/app/src/main/java/com/example/campusguide/map/GoogleMapAdapter.kt
+++ b/app/src/main/java/com/example/campusguide/map/GoogleMapAdapter.kt
@@ -61,6 +61,10 @@ class GoogleMapAdapter : Map {
         adapted.setOnInfoWindowClickListener(infoWindowClickListener)
     }
 
+    override fun setOnInfoWindowCloseListener(infoWindowCloseListener: GoogleMap.OnInfoWindowCloseListener) {
+        adapted.setOnInfoWindowCloseListener(infoWindowCloseListener)
+    }
+
     override fun addPath(path: PathPolyline) {
         path.removeFromMap()
         path.addToMap(this)

--- a/app/src/main/java/com/example/campusguide/map/Map.kt
+++ b/app/src/main/java/com/example/campusguide/map/Map.kt
@@ -19,4 +19,5 @@ interface Map {
     fun addPath(path: PathPolyline)
     fun setInfoWindowAdapter(infoWindowAdapter: GoogleMap.InfoWindowAdapter)
     fun setOnInfoWindowClickListener(infoWindowClickListener: GoogleMap.OnInfoWindowClickListener)
+    fun setOnInfoWindowCloseListener(infoWindowCloseListener: GoogleMap.OnInfoWindowCloseListener)
 }

--- a/app/src/main/java/com/example/campusguide/map/infoWindow/BuildingClickListener.kt
+++ b/app/src/main/java/com/example/campusguide/map/infoWindow/BuildingClickListener.kt
@@ -55,6 +55,9 @@ class BuildingClickListener(
             val location = Location(info.fullName!!, coordinates.latitude, coordinates.longitude)
             directions?.startFlow(null, location)
         })
+        map.setOnInfoWindowCloseListener(GoogleMap.OnInfoWindowCloseListener {
+            marker?.remove()
+        })
 
         // Clears any existing markers from the GoogleMap
         marker?.remove()

--- a/app/src/main/java/com/example/campusguide/search/PopupSearchLocationListener.kt
+++ b/app/src/main/java/com/example/campusguide/search/PopupSearchLocationListener.kt
@@ -10,7 +10,11 @@ import com.example.campusguide.search.travelWindow.TravelWindowClickListener
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.MarkerOptions
 
-class PopupSearchLocationListener constructor(private val activity: AppCompatActivity, private val directions: DirectionsFlow, private val map: GoogleMapAdapter) : SearchLocationListener {
+class PopupSearchLocationListener constructor(
+    private val activity: AppCompatActivity,
+    private val directions: DirectionsFlow,
+    private val map: GoogleMapAdapter
+) : SearchLocationListener {
     private var marker: com.example.campusguide.map.Marker? = null
 
     override fun onLocation(location: SearchLocation?) {


### PR DESCRIPTION
Added a listener that removes the map marker when a building's info window is closed.