### PR TITLE
Indoor segment no longer ignores subsequent segments in the route

### DIFF
--- a/app/src/main/java/com/example/campusguide/directions/indoor/IndoorSegment.kt
+++ b/app/src/main/java/com/example/campusguide/directions/indoor/IndoorSegment.kt
@@ -58,15 +58,19 @@ class IndoorSegment constructor(
     }
 
     override suspend fun toListOfCoordinates(): List<LatLng> {
-        return if (endRoomCode != null)
-            pathfinding.findRoom(startRoomCode, endRoomCode!!)[0]
+        return if (endRoomCode != null) {
+            val result = mutableListOf<LatLng>()
+            result.addAll(pathfinding.findRoom(startRoomCode, endRoomCode!!)[0])
+            result.addAll(next?.toListOfCoordinates() ?: emptyList())
+            return result
+        }
         else
             emptyList()
     }
 
     override fun getDuration(): Int {
         // TODO: Estimate duration of indoor path segments
-        return 0
+        return next?.getDuration() ?: 0
     }
 
     override fun getSteps(): List<GoogleDirectionsAPIStep> {

--- a/app/src/main/java/com/example/campusguide/directions/indoor/IndoorSegment.kt
+++ b/app/src/main/java/com/example/campusguide/directions/indoor/IndoorSegment.kt
@@ -63,8 +63,7 @@ class IndoorSegment constructor(
             result.addAll(pathfinding.findRoom(startRoomCode, endRoomCode!!)[0])
             result.addAll(next?.toListOfCoordinates() ?: emptyList())
             return result
-        }
-        else
+        } else
             emptyList()
     }
 

--- a/app/src/main/java/com/example/campusguide/directions/outdoor/OutdoorSegment.kt
+++ b/app/src/main/java/com/example/campusguide/directions/outdoor/OutdoorSegment.kt
@@ -54,7 +54,7 @@ class OutdoorSegment(private val start: String, private val args: SegmentArgs) :
     }
 
     override fun getDuration(): Int {
-        return route.getDuration()
+        return route.getDuration() + (next?.getDuration() ?: 0)
     }
 
     override fun getSteps(): List<GoogleDirectionsAPIStep> {


### PR DESCRIPTION
Fixes #184 

The issue was caused by IndoorSegment not calling the next segment when doing toListOfCoordinates. So any segment after an IndoorSegment was ignored.

Both kinds of segments were ignoring the next one in getDuration, so I also fixed that to call the next segment.

Screenshot proving the fix:
![image](https://user-images.githubusercontent.com/32281260/79677463-d0339700-81bf-11ea-9229-4f68016f06aa.png)
