### PR TITLE
Added error dialog using next/last event when not logged in or no calendar is selected

### DIFF
--- a/app/src/main/java/com/example/campusguide/Constants.kt
+++ b/app/src/main/java/com/example/campusguide/Constants.kt
@@ -57,4 +57,7 @@ object Constants {
     const val TITLE_RECOMMENDED_ROUTE = "RECOMMENDED_ROUTE"
     const val TITLE_LESS_WALKING = "LESS WALKING"
     const val TITLE_FEWER_TRANSFERS = "FEWER TRANSFERS"
+
+    const val NO_CALENDAR_LOGIN_EXCEPTION_MSG = "You are not logged in or you do not have a calendar set.\n" +
+        "\nPlease login and choose a calendar in the drawer menu."
 }

--- a/app/src/main/java/com/example/campusguide/directions/ChooseDestinationOptions.kt
+++ b/app/src/main/java/com/example/campusguide/directions/ChooseDestinationOptions.kt
@@ -51,11 +51,9 @@ class ChooseDestinationOptions(private val provider: SearchLocationProvider, pri
             GlobalScope.launch {
                 FindEventLocation(act, locationSelectedListener).getLocationOfEvent(nextLocation)
             }
-        }
-        catch (e: IndexOutOfBoundsException) {
+        } catch (e: IndexOutOfBoundsException) {
             activity?.let { DisplayMessageErrorListener(it).onError(
-                "You are not logged in or you do not have a calendar set.\n" +
-                    "\nPlease login and choose a calendar in the drawer menu.")
+                Constants.NO_CALENDAR_LOGIN_EXCEPTION_MSG)
             }
         }
     }

--- a/app/src/main/java/com/example/campusguide/directions/ChooseDestinationOptions.kt
+++ b/app/src/main/java/com/example/campusguide/directions/ChooseDestinationOptions.kt
@@ -16,6 +16,7 @@ import com.example.campusguide.calendar.FindEventLocation
 import com.example.campusguide.location.Location
 import com.example.campusguide.search.CustomSearch
 import com.example.campusguide.search.SearchLocationProvider
+import com.example.campusguide.utils.DisplayMessageErrorListener
 import database.ObjectBox
 import database.entity.Calendar
 import io.objectbox.Box
@@ -40,14 +41,22 @@ class ChooseDestinationOptions(private val provider: SearchLocationProvider, pri
     }
 
     private fun useNextEvent() {
-        dismiss()
-        val act = activity as MapsActivity
-        val calendarBox: Box<Calendar> = ObjectBox.boxStore.boxFor()
-        val calendar = Pair(calendarBox.all[0].id, calendarBox.all[0].name)
+        try {
+            dismiss()
+            val act = activity as MapsActivity
+            val calendarBox: Box<Calendar> = ObjectBox.boxStore.boxFor()
+            val calendar = Pair(calendarBox.all[0].id, calendarBox.all[0].name)
 
-        val nextLocation = Events(act, calendar).getNextEventLocation()
-        GlobalScope.launch {
-            FindEventLocation(act, locationSelectedListener).getLocationOfEvent(nextLocation)
+            val nextLocation = Events(act, calendar).getNextEventLocation()
+            GlobalScope.launch {
+                FindEventLocation(act, locationSelectedListener).getLocationOfEvent(nextLocation)
+            }
+        }
+        catch (e: IndexOutOfBoundsException) {
+            activity?.let { DisplayMessageErrorListener(it).onError(
+                "You are not logged in or you do not have a calendar set.\n" +
+                    "\nPlease login and choose a calendar in the drawer menu.")
+            }
         }
     }
 

--- a/app/src/main/java/com/example/campusguide/directions/ChooseOriginOptions.kt
+++ b/app/src/main/java/com/example/campusguide/directions/ChooseOriginOptions.kt
@@ -27,9 +27,9 @@ import database.ObjectBox
 import database.entity.Calendar
 import io.objectbox.Box
 import io.objectbox.kotlin.boxFor
+import java.lang.IndexOutOfBoundsException
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import java.lang.IndexOutOfBoundsException
 
 class ChooseOriginOptions(
     private val permission: PermissionsSubject,
@@ -112,11 +112,9 @@ class ChooseOriginOptions(
                     locationSelectedListener
                 ).getLocationOfEvent(lastLocation)
             }
-        }
-        catch (e: IndexOutOfBoundsException) {
+        } catch (e: IndexOutOfBoundsException) {
             activity?.let { DisplayMessageErrorListener(it).onError(
-                "You are not logged in or you do not have a calendar set.\n" +
-                    "\nPlease login and choose a calendar in the drawer menu.")
+                Constants.NO_CALENDAR_LOGIN_EXCEPTION_MSG)
             }
         }
     }

--- a/app/src/main/res/menu/options_menu.xml
+++ b/app/src/main/res/menu/options_menu.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
         <item
-            android:id="@+id/accessibility_settings"
-            android:title="Accessibility Settings"/>
-        <item
             android:id="@+id/login_button"
             android:title="Login to an Account"/>
         <item
             android:id="@+id/calendar"
-            android:title="Calendar"
+            android:title="Choose your Calendar"
             android:visible="false"/>
 </menu>


### PR DESCRIPTION
App used to crash when the user is not logged in or there is no calendar set and "Use next event" or "Use last event" was selected as a directions option. Now an error dialog appears, asking the user to login and/or select a calendar.